### PR TITLE
feature: send progress callback

### DIFF
--- a/Classes/Mailgun.h
+++ b/Classes/Mailgun.h
@@ -166,6 +166,18 @@
               success:(void (^)(NSString *messageId))success
               failure:(void (^)(NSError *error))failure;
 
+/**
+ Sends a previously constructed MGMessage with the provided success and failure blocks.
+ 
+ @param success A block called when the message is sent successfully called with a parameter `NSString` of the message id.
+ @param failure A block called when the underlying HTTP request fails. It will be called with an `NSError` set by the underlying `AFNetworking` client.
+ @param progressBlock A block object to be called when an undetermined number of bytes have been uploaded to the server. This block has no return value and takes three arguments: the number of bytes written since the last time the upload progress block was called, the total bytes written, and the total bytes expected to be written during the request, as initially determined by the length of the HTTP body. This block may be called multiple times, and will execute on the main thread.
+ */
+- (void)sendMessage:(MGMessage *)message
+            success:(void (^)(NSString *messageId))success
+            failure:(void (^)(NSError *error))failure
+		   progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progressBlock;
+
 ///-----------------------------------------
 /// @name Checking Mailing List Subscription
 ///-----------------------------------------

--- a/Classes/Mailgun.m
+++ b/Classes/Mailgun.m
@@ -79,6 +79,16 @@ NSString * const kMailgunURL = @"https://api.mailgun.net/v2";
 - (void)sendMessage:(MGMessage *)message
             success:(void (^)(NSString *messageId))success
             failure:(void (^)(NSError *error))failure {
+    [self sendMessage:message
+			  success:success
+			  failure:failure
+			 progress:nil];
+}
+
+- (void)sendMessage:(MGMessage *)message
+            success:(void (^)(NSString *messageId))success
+            failure:(void (^)(NSError *error))failure
+		   progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progressBlock {
     NSParameterAssert(message);
     AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:[self createSendRequest:message]
                                                                       success:^(AFHTTPRequestOperation *_operation, id responseObject) {
@@ -92,6 +102,9 @@ NSString * const kMailgunURL = @"https://api.mailgun.net/v2";
                                                                               failure(error);
                                                                           }
                                                                       }];
+	
+	[operation setUploadProgressBlock:progressBlock];
+	
     [self enqueueHTTPRequestOperation:operation];
 }
 


### PR DESCRIPTION
Add parameter to send message function to allow progress callback to
be set and passed to the AFHTTPRequestOperation