### PR TITLE
Feature/update afnetworking version

### DIFF
--- a/mailgun.podspec
+++ b/mailgun.podspec
@@ -11,4 +11,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes', 'Classes/*.{h,m}'
   s.requires_arc = true
   s.dependency 'AFNetworking', '~> 1.1.0'
+  s.dependency 'AFNetworking', '~> 1.3.0'
 end

--- a/mailgun.podspec
+++ b/mailgun.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.7'
   s.source_files = 'Classes', 'Classes/*.{h,m}'
   s.requires_arc = true
-  s.dependency 'AFNetworking', '~> 1.1.0'
+  s.framework	 = 'SystemConfiguration', 'MobileCoreServices'
+  s.prefix_header_contents = "#import <SystemConfiguration/SystemConfiguration.h>\n#import <MobileCoreServices/MobileCoreServices.h>"
   s.dependency 'AFNetworking', '~> 1.3.0'
 end


### PR DESCRIPTION
Two changes:
1) Currently the podspec has a dependency on AFNetworking set at '~> 1.1.0', which forces it to use versions of AFNetworking 1.1.*

I am using Restkit, which uses AFNetworking '~> 1.3.0', and there was a conflict between the AFNetworking versions. To resolve the issue, I simply updated mailgun's podfile to require AFNetworking version '~> 1.3.0', which still allows it to compile, and now has no issue.

2) There was a warning from AFNetworking regarding libraries not present at compile time. I resolved this by updating adding the necessary frameworks to the podfile in an appropriate way.